### PR TITLE
Remove test targets from CMakeLists

### DIFF
--- a/mcsexplorer/CMakeLists.txt
+++ b/mcsexplorer/CMakeLists.txt
@@ -5,9 +5,6 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_C_COMPILER "gcc-13")
 set(CMAKE_CXX_COMPILER "g++-13")
 
-include(CTest)
-enable_testing()
-
 set(
     WFLAGS
         "-Wall"


### PR DESCRIPTION
As we have not test, these lines were bloating the target list.